### PR TITLE
Add frontend authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ venv
 .idea
 chroma_db
 __pycache__
+config.yaml

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,13 @@
+To enable authentication:
+
+- in your `.env` file set `DISABLE_AUTHENTICATION=False`
+- copy the sample `config.yaml.example` file to `config.example`
+- change the username to your preferred username
+- Change the plain text password to a hashed password
+
+You can generate a password hash by running this code
+
+```
+import streamlit_authenticator as stauth
+stauth.utilities.hasher.Hasher(['abc']).generate()
+```

--- a/env.example
+++ b/env.example
@@ -3,3 +3,4 @@ GITHUB_PERSONAL_ACCESS_TOKEN=
 API_URL = "http://assistant_api:8000"
 GITHUB_REPOSITORY="domiebett/team5-langchain-final-project"
 API_KEY=
+DISABLE_AUTHENTICATION=True

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1,7 +1,12 @@
 import os
+from distutils.util import strtobool
+
+import yaml
 import requests
 import streamlit as st
+import streamlit_authenticator as stauth
 from dotenv import load_dotenv, find_dotenv
+from yaml.loader import SafeLoader
 
 from components.sidebar import sidebar
 from services.assistant import make_request
@@ -9,23 +14,69 @@ from services.assistant import make_request
 st.set_page_config(layout="wide", initial_sidebar_state="expanded")
 
 
-def launch_app():
+def launch_app(authenticator=None):
     st.title("Github PM Assistant")
 
-    status()
+    if authenticator is not None:
+        authenticator.logout()
+        st.write(f'Welcome *{st.session_state["name"]}*')
 
+    status()
     sidebar()
 
 
 def status():
     with st.spinner("Checking if API reachable..."):
-        response = make_request("get", "/healthz")
+        try:
+            response = make_request("get", "/healthz")
+        except requests.exceptions.ConnectionError:
+            st.error("API Unreachable")
+            return
+
         if response.status_code == 200:
             st.success("Healthy")
         else:
             st.error("API Unreachable")
 
 
+def get_authenticator():
+    with open("config.yaml") as file:
+        config = yaml.load(file, Loader=SafeLoader)
+
+    authenticator = stauth.Authenticate(
+        config["credentials"],
+        config["cookie"]["name"],
+        config["cookie"]["key"],
+        config["cookie"]["expiry_days"],
+    )
+    return authenticator
+
+
+def check_auth(authenticator):
+    if st.session_state["authentication_status"]:
+        return True
+
+    authenticator.login()
+
+    if st.session_state["authentication_status"]:
+        return True
+    elif st.session_state["authentication_status"] is False:
+        st.error("Username/password is incorrect")
+    elif st.session_state["authentication_status"] is None:
+        st.warning("Please enter your username and password")
+
+    return False
+
+
 if __name__ == "__main__":
     load_dotenv(find_dotenv(), override=True)
-    launch_app()
+
+    disable_auth = strtobool(os.environ.get("DISABLE_AUTHENTICATION", True))
+    if disable_auth:
+        launch_app()
+        st.stop()
+
+    authenticator = get_authenticator()
+    authenticated = check_auth(authenticator)
+    if authenticated:
+        launch_app(authenticator)

--- a/frontend/config.yaml.example
+++ b/frontend/config.yaml.example
@@ -1,0 +1,10 @@
+credentials:
+  usernames:
+    jsmith:
+      email: jsmith@gmail.com
+      name: John Smith
+      password: abc # replaced with hashed password
+cookie:
+  expiry_days: 30
+  key: random_signature_key # Must be string
+  name: random_cookie_name

--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -2,3 +2,4 @@ python-dotenv==1.0.1
 requests==2.31.0
 streamlit==1.32.2
 streamlit-chat==0.1.1
+streamlit_authenticator==0.3.2


### PR DESCRIPTION
## Context

We need to restrict access to the application in order to prevent API Quota exhaustion

# Changes
Add optional authentication to the frontend
A sample credential configuration file is added
To enable authentication:
- in your `.env` file set `DISABLE_AUTHENTICATION=False`
- copy the sample `config.yaml.example` file to `config.example`
- change the username to your preferred username
-  Change the plain text password to a hashed password 

You can generate a password hash by running this code
```
import streamlit_authenticator as stauth
stauth.utilities.hasher.Hasher(['abc']).generate()
```