### PR TITLE
enable display of issue screenshot in chat interface

### DIFF
--- a/api/services/issues.py
+++ b/api/services/issues.py
@@ -11,6 +11,7 @@ system_prompt = """
 You are a project manager assistant. Your job is to help answer questions about a github project's issues.
 The context is a combination of all github issues filtered by use of a vector database.
 Use the following pieces of context to answer the user's question.
+If your response contains an image change the `img` tag attributes to have width="100%" and height="400".
 If you don't find the answer in the provided context respond with 'I don't know'
 Context: {context}
 """

--- a/frontend/pages/project_issues_chat.py
+++ b/frontend/pages/project_issues_chat.py
@@ -58,7 +58,12 @@ def chat_interface():
         st.session_state[messages_key].append(response["response"])
 
     for i, msg in enumerate(st.session_state[messages_key]):
-        message(msg, is_user=i % 2 == 0, key=f"message{i}")
+        message(
+            msg,
+            is_user=i % 2 == 0,
+            key=f"message{i}",
+            allow_html=True,
+        )
 
     st.markdown(scroll_script, unsafe_allow_html=True)
 


### PR DESCRIPTION
Context
======
If an issue has screenshots the LLM response may contain the image link

Changes
=======
Instruct the LLM to set the `img` height attribute if its response contains and image

<img width="1132" alt="Screenshot 2024-03-28 at 22 32 42" src="https://github.com/domiebett/team5-langchain-final-project/assets/200889/24fddef6-59f3-4ca0-89fe-e8116d640533">
